### PR TITLE
Use lz4 module from runtime

### DIFF
--- a/org.virt_manager.virt-viewer.yml
+++ b/org.virt_manager.virt-viewer.yml
@@ -26,20 +26,6 @@ cleanup:
   - "*.la"
   - "*.a"
 modules:
-  - name: lz4
-    build-options:
-      env:
-        PREFIX: /app
-    buildsystem: simple
-    build-commands:
-      - make -j $FLATPAK_BUILDER_N_JOBS
-      - make install
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: https://github.com/lz4/lz4/archive/refs/tags/v1.10.0.tar.gz
-        sha256: 537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
   - name: gtk-vnc
     buildsystem: meson
     cleanup:


### PR DESCRIPTION
GNOME runtime 48 (based on the Freedesktop runtime version 24.08) appears to provide the **lz4** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/lz4.bst

Fixes: https://github.com/flathub/org.virt_manager.virt-viewer/issues/9